### PR TITLE
fix: preserve leading comments when removing moved blocks

### DIFF
--- a/cmd/terraform-moved-remover/integration_test.go
+++ b/cmd/terraform-moved-remover/integration_test.go
@@ -248,7 +248,7 @@ resource "aws_instance" "web" {
 	if err != nil {
 		t.Fatalf("Failed to read modified file: %v", err)
 	}
-	
+
 	// The file should be empty or contain only whitespace
 	if len(content) > 0 && len(string(content)) > 0 {
 		contentStr := string(content)
@@ -259,4 +259,175 @@ resource "aws_instance" "web" {
 			}
 		}
 	}
+}
+
+// TestLeadingCommentsPreserved tests that comments preceding moved blocks
+// are NOT removed along with the moved block.
+// This reproduces the issue where hclwrite.RemoveBlock() removes leading
+// comments that are attached to the block as child nodes.
+func TestLeadingCommentsPreserved(t *testing.T) {
+	testDir, err := os.MkdirTemp("", "terraform-comment-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(testDir)
+
+	// Case 1: Comment directly before moved block (no blank line) — gets eaten by RemoveBlock
+	t.Run("comment_directly_before_moved_block", func(t *testing.T) {
+		filePath := filepath.Join(testDir, "case1.tf")
+		input := `resource "aws_instance" "web" {
+  ami           = "ami-123456"
+  instance_type = "t2.micro"
+}
+
+# This comment describes the resource migration
+moved {
+  from = aws_instance.old
+  to   = aws_instance.web
+}
+`
+		if err := os.WriteFile(filePath, []byte(input), 0644); err != nil {
+			t.Fatalf("Failed to write test file: %v", err)
+		}
+
+		stats := Stats{}
+		if err := processFile(filePath, &stats); err != nil {
+			t.Fatalf("processFile failed: %v", err)
+		}
+
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			t.Fatalf("Failed to read modified file: %v", err)
+		}
+
+		result := string(content)
+		t.Logf("Case 1 output:\n%s", result)
+
+		if strings.Contains(result, "moved {") {
+			t.Error("moved block should have been removed")
+		}
+		// This is the key assertion: the comment should be preserved
+		if !strings.Contains(result, "# This comment describes the resource migration") {
+			t.Error("Leading comment was removed along with the moved block — this is the bug")
+		}
+	})
+
+	// Case 2: Multiple comment lines directly before moved block
+	t.Run("multiple_comments_before_moved_block", func(t *testing.T) {
+		filePath := filepath.Join(testDir, "case2.tf")
+		input := `resource "aws_instance" "web" {
+  ami           = "ami-123456"
+  instance_type = "t2.micro"
+}
+
+# Description of the migration
+# import id: arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0
+moved {
+  from = aws_instance.old
+  to   = aws_instance.web
+}
+`
+		if err := os.WriteFile(filePath, []byte(input), 0644); err != nil {
+			t.Fatalf("Failed to write test file: %v", err)
+		}
+
+		stats := Stats{}
+		if err := processFile(filePath, &stats); err != nil {
+			t.Fatalf("processFile failed: %v", err)
+		}
+
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			t.Fatalf("Failed to read modified file: %v", err)
+		}
+
+		result := string(content)
+		t.Logf("Case 2 output:\n%s", result)
+
+		if !strings.Contains(result, "# Description of the migration") {
+			t.Error("First comment line was removed along with the moved block")
+		}
+		if !strings.Contains(result, "# import id:") {
+			t.Error("Second comment line was removed along with the moved block")
+		}
+	})
+
+	// Case 3: Blank line separates comment from moved block — should survive
+	t.Run("comment_separated_by_blank_line", func(t *testing.T) {
+		filePath := filepath.Join(testDir, "case3.tf")
+		input := `resource "aws_instance" "web" {
+  ami           = "ami-123456"
+  instance_type = "t2.micro"
+}
+
+# This comment is separated by a blank line
+
+moved {
+  from = aws_instance.old
+  to   = aws_instance.web
+}
+`
+		if err := os.WriteFile(filePath, []byte(input), 0644); err != nil {
+			t.Fatalf("Failed to write test file: %v", err)
+		}
+
+		stats := Stats{}
+		if err := processFile(filePath, &stats); err != nil {
+			t.Fatalf("processFile failed: %v", err)
+		}
+
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			t.Fatalf("Failed to read modified file: %v", err)
+		}
+
+		result := string(content)
+		t.Logf("Case 3 output:\n%s", result)
+
+		// Blank line breaks the lead comment association, so this should survive
+		if !strings.Contains(result, "# This comment is separated by a blank line") {
+			t.Error("Comment separated by blank line was unexpectedly removed")
+		}
+	})
+
+	// Case 4: Comment belongs to the NEXT resource, not the moved block
+	t.Run("comment_between_moved_and_resource", func(t *testing.T) {
+		filePath := filepath.Join(testDir, "case4.tf")
+		input := `resource "aws_instance" "web" {
+  ami           = "ami-123456"
+  instance_type = "t2.micro"
+}
+
+# Describes the S3 bucket below
+moved {
+  from = aws_instance.old
+  to   = aws_instance.web
+}
+
+resource "aws_s3_bucket" "data" {
+  bucket = "my-data-bucket"
+}
+`
+		if err := os.WriteFile(filePath, []byte(input), 0644); err != nil {
+			t.Fatalf("Failed to write test file: %v", err)
+		}
+
+		stats := Stats{}
+		if err := processFile(filePath, &stats); err != nil {
+			t.Fatalf("processFile failed: %v", err)
+		}
+
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			t.Fatalf("Failed to read modified file: %v", err)
+		}
+
+		result := string(content)
+		t.Logf("Case 4 output:\n%s", result)
+
+		// This comment was directly before the moved block, so hclwrite eats it
+		if !strings.Contains(result, "# Describes the S3 bucket below") {
+			t.Error("Comment that semantically belongs to another resource was removed with the moved block")
+		}
+	})
 }

--- a/cmd/terraform-moved-remover/main.go
+++ b/cmd/terraform-moved-remover/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
 
@@ -54,47 +55,81 @@ func processFile(filePath string, stats *Stats) error {
 		return fmt.Errorf("error reading file %s: %w", filePath, err)
 	}
 
-	// Parse HCL file
-	file, diags := hclwrite.ParseConfig(content, filePath, hcl.Pos{Line: 1, Column: 1})
+	// Parse with hclsyntax to get block ranges that exclude leading comments
+	syntaxFile, diags := hclsyntax.ParseConfig(content, filePath, hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
 		return fmt.Errorf("error parsing %s: %s", filePath, diags.Error())
 	}
 
-	// Track if file was modified
-	fileModified := false
-	movedBlocksCount := 0
+	syntaxBody, ok := syntaxFile.Body.(*hclsyntax.Body)
+	if !ok {
+		return fmt.Errorf("unexpected body type in %s", filePath)
+	}
 
-	// Find and remove moved blocks
-	body := file.Body()
-	for _, block := range body.Blocks() {
-		if block.Type() == "moved" {
-			body.RemoveBlock(block)
-			movedBlocksCount++
-			fileModified = true
+	// Collect byte ranges of moved blocks (SrcRange excludes leading comments)
+	type byteRange struct {
+		start, end int
+	}
+	var movedRanges []byteRange
+	for _, block := range syntaxBody.Blocks {
+		if block.Type == "moved" {
+			r := block.Range()
+			movedRanges = append(movedRanges, byteRange{start: r.Start.Byte, end: r.End.Byte})
 		}
 	}
 
+	movedBlocksCount := len(movedRanges)
+	fileModified := movedBlocksCount > 0
+
 	// Update statistics
 	stats.FilesProcessed++
-	
-	// Apply formatting to all files, not just those with moved blocks
+
 	// Write modified content back to file only if not in dry run mode
 	if !stats.DryRun {
+		resultContent := content
+		if fileModified {
+			// Remove moved blocks from content in reverse order to preserve byte offsets
+			result := make([]byte, len(content))
+			copy(result, content)
+
+			for i := len(movedRanges) - 1; i >= 0; i-- {
+				r := movedRanges[i]
+				start := r.start
+				end := r.end
+
+				// Consume leading whitespace on the same line as `moved`
+				for start > 0 && (result[start-1] == ' ' || result[start-1] == '\t') {
+					start--
+				}
+
+				// Consume trailing newline after closing brace
+				for end < len(result) && (result[end] == '\r' || result[end] == '\n') {
+					end++
+					if result[end-1] == '\n' {
+						break
+					}
+				}
+
+				result = append(result[:start], result[end:]...)
+			}
+			resultContent = result
+		}
+
 		// Format the file content
-		formattedContent := hclwrite.Format(file.Bytes())
-		
+		formattedContent := hclwrite.Format(resultContent)
+
 		// Fix excessive newlines that may result from removing consecutive moved blocks
 		if fileModified && stats.NormalizeWhitespace {
 			formattedContent = normalizeConsecutiveNewlines(formattedContent)
 		}
-		
+
 		if fileModified || !bytes.Equal(formattedContent, content) {
 			stats.FilesModified++
-			
+
 			if fileModified {
 				stats.MovedBlocksRemoved += movedBlocksCount
 			}
-			
+
 			err = os.WriteFile(filePath, formattedContent, 0644)
 			if err != nil {
 				return fmt.Errorf("error writing file %s: %w", filePath, err)


### PR DESCRIPTION
## Summary

- Fix an issue where `hclwrite.RemoveBlock()` removes leading comments along with the block, because hclwrite internally stores preceding comments as child nodes of the block
- Switch to `hclsyntax.ParseConfig()` to obtain precise byte ranges of moved blocks (excluding leading comments), then remove blocks at the byte level
- Add 4 test cases to verify comment preservation behavior

## Test plan

- [x] All existing tests pass
- [x] Comment directly before a moved block is preserved after removal
- [x] Multiple comment lines directly before a moved block are all preserved
- [x] Comment separated by a blank line continues to be preserved
- [x] Comment semantically belonging to another resource is not removed with the moved block